### PR TITLE
Flush the entire queue before exiting.

### DIFF
--- a/lib/segment/analytics/worker.rb
+++ b/lib/segment/analytics/worker.rb
@@ -36,6 +36,20 @@ module Segment
         until Thread.current[:should_exit]
           return if @queue.empty?
 
+          flush_queue
+        end
+      end
+
+      # public: Check whether we have outstanding requests.
+      #
+      def is_requesting?
+        @lock.synchronize { !@batch.empty? }
+      end
+
+      private
+
+      def flush_queue
+        until @queue.empty?
           @lock.synchronize do
             until @batch.length >= @batch_size || @queue.empty?
               @batch << @queue.pop
@@ -48,12 +62,6 @@ module Segment
 
           @lock.synchronize { @batch.clear }
         end
-      end
-
-      # public: Check whether we have outstanding requests.
-      #
-      def is_requesting?
-        @lock.synchronize { !@batch.empty? }
       end
     end
   end

--- a/spec/segment/analytics/worker_spec.rb
+++ b/spec/segment/analytics/worker_spec.rb
@@ -74,6 +74,21 @@ module Segment
 
           expect(queue).to be_empty
         end
+
+        context 'should exit is set' do
+          it 'does not return until the queue is empty' do
+            allow_any_instance_of(Thread).to receive(:[]).with(:should_exit).and_return(false, true)
+
+            queue = Queue.new
+            queue << Requested::TRACK
+            queue << Requested::TRACK
+            queue << Requested::TRACK
+            worker = Segment::Analytics::Worker.new queue, 'testsecret', :batch_size => 1
+            worker.run
+
+            expect(queue).to be_empty
+          end
+        end
       end
 
       describe '#is_requesting?' do


### PR DESCRIPTION
If the batch size is smaller than the queue length, currently items will be left in the queue when `should_exit` is true. This adds an additional loop and test case to ensure that the queue is fully drained before exiting.